### PR TITLE
Add Symfony 6 compatibility, bugfixes, and minor improvements.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,4 @@ vendor/*
 .idea
 
 # PHPUnit
-.phpunit*
+.phpunit.result.cache

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # Composer
-vendor/*
 composer.lock
+vendor/*
 
 # PHPStorm
 .idea
+
+# PHPUnit
+.phpunit*

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,28 +8,11 @@ cache:
 
 matrix:
   include:
-    - php: 5.3
-      dist: precise
-    - php: 5.4
-      env: COMPOSER_FLAGS="--prefer-lowest"
-      dist: precise
-    - php: 5.5
-      dist: precise
-    - php: 5.6
-      env: SYMFONY_LTS=v3 DEPENDENCIES=dev COMPOSER_FLAGS="--prefer-stable"
-    - php: 7.0
-      env: SYMFONY_LTS=v2
-    - php: 7.1
-    - php: 7.2
-    - php: 7.3
-    - php: 7.4
-    - php: 8.0
+    - php: 8.0.2
+    - php: 8.1
+    - php: 8.2
 
-before_install:
-  - if [ "$SYMFONY_LTS" != "" ]; then composer require --dev --no-update symfony/lts=$SYMFONY_LTS; fi
-  - if [ "$DEPENDENCIES" = "dev" ]; then composer config minimum-stability dev; fi;
-
-install: travis_retry composer update $COMPOSER_FLAGS
+install: travis_retry composer update
 
 script:
   - php vendor/bin/phpunit --coverage-text

--- a/README.md
+++ b/README.md
@@ -7,11 +7,6 @@ Currently, it is extremely naive and incomplete. However, it does what we need i
 
 [![Build Status](https://secure.travis-ci.org/hautelook/TemplatedUriRouter.png?branch=master)](https://travis-ci.org/hautelook/TemplatedUriRouter)
 
-## Requirements
-
-- PHP 8.0.2 or greater
-- Symfony Routing component 6.0 or greater
-
 ## Installation
 
 Run the following command (assuming you have composer.phar or composer binary installed), or

--- a/README.md
+++ b/README.md
@@ -1,11 +1,16 @@
 Hautelook Templated URI Router
 ==============================
 
-Symfony2 UrlGenerator that provides a [RFC-6570][RFC-6570] compatible router and URL Generator.
-Currently it is extremely naive, and incomplete.
-However, it does what we need it to do. Contributions are welcome.
+Symfony URL generator that provides an [RFC-6570](https://tools.ietf.org/html/rfc6570)-compatible router.
+
+Currently, it is extremely naive and incomplete. However, it does what we need it to do. Contributions are welcome.
 
 [![Build Status](https://secure.travis-ci.org/hautelook/TemplatedUriRouter.png?branch=master)](https://travis-ci.org/hautelook/TemplatedUriRouter)
+
+## Requirements
+
+- PHP 8.0.2 or greater
+- Symfony Routing component 6.0 or greater
 
 ## Installation
 
@@ -43,8 +48,7 @@ This will produce a link similar to:
 
 ## Bundle
 
-The symfony2 bundle lives at
+The Symfony bundle lives at
 [https://github.com/hautelook/TemplatedUriBundle](https://github.com/hautelook/TemplatedUriBundle).
 
 [RFC-6570]: https://tools.ietf.org/html/rfc6570
-

--- a/Routing/Generator/BcUrlGenerator.php
+++ b/Routing/Generator/BcUrlGenerator.php
@@ -2,16 +2,8 @@
 
 namespace Hautelook\TemplatedUriRouter\Routing\Generator;
 
-use Symfony\Component\HttpKernel\Kernel;
 use Symfony\Component\Routing\Generator\CompiledUrlGenerator;
-use Symfony\Component\Routing\Generator\UrlGenerator;
 
-if (!class_exists('Symfony\Component\Routing\Generator\CompiledUrlGenerator')) {
-    abstract class BcUrlGenerator extends UrlGenerator
-    {
-    }
-} else {
-    abstract class BcUrlGenerator extends CompiledUrlGenerator
-    {
-    }
+abstract class BcUrlGenerator extends CompiledUrlGenerator
+{
 }

--- a/Routing/Generator/BcUrlGenerator.php
+++ b/Routing/Generator/BcUrlGenerator.php
@@ -1,9 +1,0 @@
-<?php
-
-namespace Hautelook\TemplatedUriRouter\Routing\Generator;
-
-use Symfony\Component\Routing\Generator\CompiledUrlGenerator;
-
-abstract class BcUrlGenerator extends CompiledUrlGenerator
-{
-}

--- a/Routing/Generator/Rfc6570Generator.php
+++ b/Routing/Generator/Rfc6570Generator.php
@@ -13,6 +13,7 @@ namespace Hautelook\TemplatedUriRouter\Routing\Generator;
 
 use Symfony\Component\Routing\Exception\InvalidParameterException;
 use Symfony\Component\Routing\Exception\MissingMandatoryParametersException;
+use Symfony\Component\Routing\Generator\CompiledUrlGenerator;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Routing\Generator\ConfigurableRequirementsInterface;
 
@@ -26,7 +27,7 @@ use Symfony\Component\Routing\Generator\ConfigurableRequirementsInterface;
  *
  * @api
  */
-class Rfc6570Generator extends BcUrlGenerator implements UrlGeneratorInterface, ConfigurableRequirementsInterface
+class Rfc6570Generator extends CompiledUrlGenerator implements UrlGeneratorInterface, ConfigurableRequirementsInterface
 {
     /**
      * @throws MissingMandatoryParametersException When some parameters are missing that mandatory for the route

--- a/Routing/Generator/Rfc6570Generator.php
+++ b/Routing/Generator/Rfc6570Generator.php
@@ -18,6 +18,7 @@ use Symfony\Component\Routing\Generator\ConfigurableRequirementsInterface;
 
 /**
  * UrlGenerator generates a URL template according to RFC6570 based on a set of routes.
+ *
  * @link https://tools.ietf.org/html/rfc6570
  *
  * @author Fabien Potencier <fabien@symfony.com>
@@ -32,7 +33,7 @@ class Rfc6570Generator extends BcUrlGenerator implements UrlGeneratorInterface, 
      * @throws InvalidParameterException           When a parameter value for a placeholder is not correct because
      *                                             it does not match the requirement
      */
-    protected function doGenerate($variables, $defaults, $requirements, $tokens, $parameters, $name, $referenceType, $hostTokens, array $requiredSchemes = array())
+    protected function doGenerate(array $variables, array $defaults, array $requirements, array $tokens, array $parameters, string $name, int $referenceType, array $hostTokens, array $requiredSchemes = []): string
     {
         // These are needed for encoded URLs, such as /resize/{width}x{height}/image/
         $this->decodedChars['%7B'] = '{';
@@ -62,7 +63,7 @@ class Rfc6570Generator extends BcUrlGenerator implements UrlGeneratorInterface, 
                             $this->logger->error($message);
                         }
 
-                        return null;
+                        return '';
                     }
 
                     $url = $token[1].$mergedParams[$token[3]].$url;
@@ -115,7 +116,7 @@ class Rfc6570Generator extends BcUrlGenerator implements UrlGeneratorInterface, 
                                 $this->logger->error($message);
                             }
 
-                            return null;
+                            return '';
                         }
 
                         $routeHost = $token[1].$mergedParams[$token[3]].$routeHost;
@@ -153,7 +154,7 @@ class Rfc6570Generator extends BcUrlGenerator implements UrlGeneratorInterface, 
 
         // add a query string if needed
         $extra = array_diff_key($parameters, $variables, $defaults);
-        if (is_array($extra) && !empty($extra)) {
+        if (!empty($extra)) {
             $parts = array();
             foreach ($extra as $key => $value) {
                 if (is_scalar($value)) {
@@ -168,7 +169,7 @@ class Rfc6570Generator extends BcUrlGenerator implements UrlGeneratorInterface, 
         return $url;
     }
 
-    private function isPlaceHolder($param)
+    private function isPlaceHolder($param): bool
     {
         $length = strlen($param);
 

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "hautelook/templated-uri-router",
     "description": "Symfony URL generator that provides an RFC-6570-compatible router.",
     "keywords": [
-        "Symfony6",
+        "Symfony",
         "URI",
         "URL",
         "RFC 6570",

--- a/composer.json
+++ b/composer.json
@@ -1,8 +1,8 @@
 {
     "name": "hautelook/templated-uri-router",
-    "description": "Symfony2 RFC-6570 compatible router and URL Generator",
+    "description": "Symfony URL generator that provides an RFC-6570-compatible router.",
     "keywords": [
-        "Symfony2",
+        "Symfony6",
         "URI",
         "URL",
         "RFC 6570",
@@ -20,11 +20,11 @@
         }
     ],
     "require": {
-        "php": ">=5.3.0",
-        "symfony/routing": "~2.5|~3.0|^4.0|^5.0|^6.0"
+        "php": ">=8.0.2",
+        "symfony/routing": "^6.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.8.35|^5.7|^6.5"
+        "phpunit/phpunit": "^9.0"
     },
     "autoload": {
         "psr-4": {
@@ -33,7 +33,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "3.0-dev"
+            "dev-master": "4.0-dev"
         }
     }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,18 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit colors="true" bootstrap="Tests/bootstrap.php">
-    <testsuites>
-        <testsuite name="HautelookTemplatedUriRouter Test Suite">
-            <directory>./Tests</directory>
-        </testsuite>
-    </testsuites>
-
-    <filter>
-        <whitelist>
-            <directory>./</directory>
-            <exclude>
-                <directory>./vendor</directory>
-                <directory>./Tests</directory>
-            </exclude>
-        </whitelist>
-    </filter>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" bootstrap="Tests/bootstrap.php" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory>./</directory>
+    </include>
+    <exclude>
+      <directory>./vendor</directory>
+      <directory>./Tests</directory>
+    </exclude>
+  </coverage>
+  <testsuites>
+    <testsuite name="HautelookTemplatedUriRouter Test Suite">
+      <directory>./Tests</directory>
+    </testsuite>
+  </testsuites>
 </phpunit>


### PR DESCRIPTION
The previous Symfony 6 PR updated dependencies, but did not actually update the codebase to support those dependencies.

This PR fixes an issue with `Rfc6570Generator` not matching Symfony 6.0's new `UrlGenerator#doGenerate()` method signature (it should return `string`), and also fixes some tests so that they actually pass.

Minimum Symfony and PHP versions have also been upgraded to 6.0 and 8.0 respectively.

Travis CI changes have not been tested.